### PR TITLE
Submit GitHub repo to the leaderboard

### DIFF
--- a/plugins/submit-to-leaderboard/index.js
+++ b/plugins/submit-to-leaderboard/index.js
@@ -8,6 +8,10 @@ module.exports = {
 
     // normalize the repo URL to be a public https URL
     let repoURL = process.env.REPOSITORY_URL;
+    if (!repoURL) {
+      console.error('REPOSITORY_URL not set for build.');
+      return;
+    }
     if (repoURL.startsWith('git@github.com:')) {
       repoURL = 'https://github.com/' + repoURL.split(':')[1];
       console.log(`Formatting repoURL from ${process.env.REPOSITORY_URL} to ${repoURL}`);
@@ -34,6 +38,17 @@ module.exports = {
       return;
     }
 
+    // Get the GitHub username from the repo URL
+    let repoURL = process.env.REPOSITORY_URL || '';
+    if (repoURL.length === 0) {
+      console.error('REPOSITORY_URL not set. Cannot get GitHub username.');
+    }
+    if (repoURL.startsWith('git@github.com:')) {
+      repoURL = 'https://github.com/' + repoURL.split(':')[1];
+      console.log(`Formatting repoURL from ${process.env.REPOSITORY_URL} to ${repoURL}`);
+    }
+    const githubUsername = repoURL.replace('https://github.com/', '').split('/')[0];
+
     // Normalize the URL to remove any protocol differences
     const url = new URL(process.env.URL);
     const siteURL = `https://${url.hostname}`;
@@ -47,7 +62,7 @@ module.exports = {
       },
       body: JSON.stringify({
         url: siteURL,
-        excluded: false,
+        username: githubUsername,
       }),
     });
   },

--- a/plugins/submit-to-leaderboard/index.js
+++ b/plugins/submit-to-leaderboard/index.js
@@ -1,21 +1,31 @@
 const fs = require('fs');
 const path = require('path');
 
+/**
+ * Format the repo URL to be a public https URL
+ *
+ * @param {string} repoURL - The repo URL to format
+ * @returns {string} - The formatted repo URL
+ */
+function formatRepoURL(repoURL = '') {
+  if (repoURL.startsWith('git@github.com:')) {
+    repoURL = 'https://github.com/' + repoURL.split(':')[1];
+    console.log(`Formatting repoURL from ${process.env.REPOSITORY_URL} to ${repoURL}`);
+  }
+  return repoURL;
+}
+
 module.exports = {
   onPreBuild: async () => {
     // Stash some env vars for later when they are not usually available to use
     const filePath = path.join(__dirname, '../../netlify/data.json');
 
-    // normalize the repo URL to be a public https URL
-    let repoURL = process.env.REPOSITORY_URL;
+    const repoURL = formatRepoURL(process.env.REPOSITORY_URL);
     if (!repoURL) {
       console.error('REPOSITORY_URL not set for build.');
       return;
     }
-    if (repoURL.startsWith('git@github.com:')) {
-      repoURL = 'https://github.com/' + repoURL.split(':')[1];
-      console.log(`Formatting repoURL from ${process.env.REPOSITORY_URL} to ${repoURL}`);
-    }
+
     const content = {
       default: {
         repoURL: repoURL,
@@ -38,20 +48,11 @@ module.exports = {
       return;
     }
 
-    // Get the GitHub username from the repo URL
-    let repoURL = process.env.REPOSITORY_URL || '';
-    if (repoURL.length === 0) {
-      console.error('REPOSITORY_URL not set. Cannot get GitHub username.');
-    }
-    if (repoURL.startsWith('git@github.com:')) {
-      repoURL = 'https://github.com/' + repoURL.split(':')[1];
-      console.log(`Formatting repoURL from ${process.env.REPOSITORY_URL} to ${repoURL}`);
-    }
-    const githubUsername = repoURL.replace('https://github.com/', '').split('/')[0];
-
     // Normalize the URL to remove any protocol differences
     const url = new URL(process.env.URL);
     const siteURL = `https://${url.hostname}`;
+
+    const repoURL = formatRepoURL(process.env.REPOSITORY_URL);
 
     console.log(`Registering ${siteURL} in the leaderboard`);
 
@@ -62,7 +63,7 @@ module.exports = {
       },
       body: JSON.stringify({
         url: siteURL,
-        username: githubUsername,
+        repoUrl: repoURL,
       }),
     });
   },


### PR DESCRIPTION
Includes the `REPOSITORY_URL` in the leaderboard submission. 

This also removes sending `exclude` to the leaderboard, which we don't need. The leaderboard will assume `false` by default. But this way. But there's not a need to set back to false once it's been excluded. So this doesn't provide us any benefit.