### PR TITLE
Don't auto-increment the count in the store on each page load

### DIFF
--- a/netlify/edge-functions/count.mts
+++ b/netlify/edge-functions/count.mts
@@ -4,9 +4,7 @@ import { getStore } from '@netlify/blobs';
 
 export default async (_request: Request, context: Context) => {
   const store = getStore('myCounter');
-  let count: number = parseInt(await store.get('count')) || 0;
-  count = count + 1;
-  await store.set('count', count.toString());
+  const count: number = parseInt(await store.get('count')) || 0;
 
   const resp = await context.next();
   return new HTMLRewriter()


### PR DESCRIPTION
This is causing unnecessary complications with the leaderboard because every time the leaderboard polls, the count is higher. We want some sort of "activity" to be what causes the count to change.

Fixes #7 